### PR TITLE
infra: rework config to properly publish dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "zod": "^3.25"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --project publish.tsconfig.json",
     "clean": "rm -rf ./dist",
     "test": "vitest run --coverage --silent='passed-only'",
     "tdd": "vitest",

--- a/publish.tsconfig.json
+++ b/publish.tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "include": [
+    "./src"
+  ],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "noEmit": false,
+    "removeComments": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
       "es2022"
     ],
     "noUncheckedIndexedAccess": true,
-    "outDir": "dist",
+    "noEmit": true,
     "paths": {
       // These correspond to the public API imports as defined in `"exports"` in
       // `package.json`. (This way the tests can run -- and, critically, they


### PR DESCRIPTION
- Don't include `src` and `test` in output.
- Do include types and source maps in output.